### PR TITLE
typo

### DIFF
--- a/cluster/manifests/ci/base/github_pr_merge_sensor.yaml
+++ b/cluster/manifests/ci/base/github_pr_merge_sensor.yaml
@@ -22,7 +22,7 @@ spec:
             type: string
             value:
               - closed
-          - path: body.pull_requests.merged
+          - path: body.pull_request.merged
             type: bool
             value:
               - "true"


### PR DESCRIPTION
Fixing a typo

```
discarded due to filtering error: data filter error (path 'body.pull_requests.merged' does not exist)
```