### PR TITLE
form reload on reset

### DIFF
--- a/frontend/pulse3d/src/pages/upload-form.js
+++ b/frontend/pulse3d/src/pages/upload-form.js
@@ -485,7 +485,9 @@ export default function UploadForm() {
             position="relative"
             borderRadius="3px"
             label="Reset"
-            clickFn={resetState}
+            clickFn={() => {
+              window.location.reload();
+            }}
           />
           <ButtonWidget
             width="135px"


### PR DESCRIPTION
The component used for dragging files keeps its own state of files. When resetting the form, everything gets reset except the the internal state of the file drag component (this component is imported from a library). So when uploading a new file of a different name all functions as should. Uploading a file of the same name does not work because the internal state of the drag component does not change, does not fire the file change event.  Looking at the docs of the library, it does not seem that they have that level of control for external users.  Instead I reload the page when the user clicks reset.