### PR TITLE
Link to metric definitions

### DIFF
--- a/frontend/pulse3d/src/components/layouts/ControlPanel.js
+++ b/frontend/pulse3d/src/components/layouts/ControlPanel.js
@@ -145,6 +145,7 @@ export default function ControlPanel() {
       page: "/account",
       options: [],
     },
+    { label: "Metric Definitions", options: [] },
   ];
 
   const buttons = accountType === "admin" ? adminButtons : userButtons;
@@ -190,6 +191,11 @@ export default function ControlPanel() {
 
           const handleSelected = (e) => {
             e.preventDefault();
+            //if metric definitions button then open window with metric definitions
+            if (label === userButtons[3].label) {
+              window.open("https://pulse3d.readthedocs.io/en/latest/gettingstarted.html#jupyter-notebooks");
+              return;
+            }
             setSelected(label);
 
             if (options.length === 0) {

--- a/frontend/pulse3d/src/package.json
+++ b/frontend/pulse3d/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "_ce": "node ./check-engines.js",


### PR DESCRIPTION
Added a button under `Account Settings` that opens a new tab with the pulse3d docs.

https://user-images.githubusercontent.com/46114925/207988306-e96c7677-6ec7-4ace-b936-454689aeb931.mp4

