### PR TITLE
peaks and valleys IA bug

### DIFF
--- a/frontend/pulse3d/src/components/interactiveAnalysis/InteractiveAnalysisModal.js
+++ b/frontend/pulse3d/src/components/interactiveAnalysis/InteractiveAnalysisModal.js
@@ -542,6 +542,8 @@ export default function InteractiveWaveformModal({
 
   const filterPeaksValleys = async () => {
     const filtered = {};
+    const { startTime, endTime } = JSON.parse(JSON.stringify(editableStartEndTimes));
+
     for (const well of Object.keys(editablePeaksValleys)) {
       let wellPeaks = editablePeaksValleys[well][0];
       let wellValleys = editablePeaksValleys[well][1];


### PR DESCRIPTION
`startTime` and `endTime` were undefined so the filtering marked all peak and valleys as false and did not include them in the final filtered array.