### PR TITLE
changed filtering in handleNewAnalysis

### DIFF
--- a/frontend/pulse3d/src/components/interactiveAnalysis/InteractiveAnalysisModal.js
+++ b/frontend/pulse3d/src/components/interactiveAnalysis/InteractiveAnalysisModal.js
@@ -803,17 +803,8 @@ export default function InteractiveWaveformModal({
 
       if (changesCopy.length > 0) {
         // grab state from the step before the undo step to set as current state
-        const {
-          peaks,
-          valleys,
-          startTime,
-          endTime,
-          pvWindow,
-          valleyYOne,
-          valleyYTwo,
-          peakYOne,
-          peakYTwo,
-        } = changesCopy[changesCopy.length - 1];
+        const { peaks, valleys, startTime, endTime, pvWindow, valleyYOne, valleyYTwo, peakYOne, peakYTwo } =
+          changesCopy[changesCopy.length - 1];
         // set old peaks and valleys to well
         peaksValleysCopy[selectedWell] = [[...peaks], [...valleys]];
         pvWindowCopy[selectedWell] = pvWindow;

--- a/frontend/pulse3d/src/components/interactiveAnalysis/InteractiveAnalysisModal.js
+++ b/frontend/pulse3d/src/components/interactiveAnalysis/InteractiveAnalysisModal.js
@@ -803,8 +803,17 @@ export default function InteractiveWaveformModal({
 
       if (changesCopy.length > 0) {
         // grab state from the step before the undo step to set as current state
-        const { peaks, valleys, startTime, endTime, pvWindow, valleyYOne, valleyYTwo, peakYOne, peakYTwo } =
-          changesCopy[changesCopy.length - 1];
+        const {
+          peaks,
+          valleys,
+          startTime,
+          endTime,
+          pvWindow,
+          valleyYOne,
+          valleyYTwo,
+          peakYOne,
+          peakYTwo,
+        } = changesCopy[changesCopy.length - 1];
         // set old peaks and valleys to well
         peaksValleysCopy[selectedWell] = [[...peaks], [...valleys]];
         pvWindowCopy[selectedWell] = pvWindow;

--- a/frontend/pulse3d/src/pages/upload-form.js
+++ b/frontend/pulse3d/src/pages/upload-form.js
@@ -265,7 +265,6 @@ export default function UploadForm() {
   };
 
   const postNewJob = async (uploadId, filename) => {
-    console.log("posting job");
     try {
       const {
         normalizeYAxis,

--- a/frontend/pulse3d/src/pages/upload-form.js
+++ b/frontend/pulse3d/src/pages/upload-form.js
@@ -265,6 +265,7 @@ export default function UploadForm() {
   };
 
   const postNewJob = async (uploadId, filename) => {
+    console.log("posting job");
     try {
       const {
         normalizeYAxis,
@@ -455,9 +456,12 @@ export default function UploadForm() {
       setInProgress(true);
 
       for (const file of files) {
+        //check file is in uploads list
+        const fileIsInList = uploads.some((upload) => upload.id === file.id);
         if (file instanceof File) {
           await uploadFile(file);
-        } else if (uploads.includes(file)) {
+        } else if (fileIsInList) {
+          console.log("posting job");
           await postNewJob(file.id, file.filename);
         }
       }

--- a/frontend/pulse3d/src/pages/upload-form.js
+++ b/frontend/pulse3d/src/pages/upload-form.js
@@ -460,7 +460,6 @@ export default function UploadForm() {
         if (file instanceof File) {
           await uploadFile(file);
         } else if (fileIsInList) {
-          console.log("posting job");
           await postNewJob(file.id, file.filename);
         }
       }


### PR DESCRIPTION
Jobs were not being posted for re-analyze option because `includes` was not matching a file object when checking if file data already exists. The check now iterates over all file id's instead of whole object when checking if file data is already present. 