### PR TITLE
Structlog dep fix

### DIFF
--- a/core/lib/utils/requirements.txt
+++ b/core/lib/utils/requirements.txt
@@ -7,3 +7,4 @@ s3transfer==0.6.1
 six==1.16.0
 urllib3==1.26.9
 structlog==23.2.0
+starlette-context==0.3.6

--- a/core/lib/utils/utils/logging.py
+++ b/core/lib/utils/utils/logging.py
@@ -30,7 +30,6 @@ def drop_color_message_key(_, __, event_dict: EventDict) -> EventDict:
 
 def setup_logger():
     shared_processors: list[Processor] = [
-        # structlog.threadlocal.merge_threadlocal,
         structlog.contextvars.merge_contextvars,
         drop_color_message_key,
         structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S"),

--- a/core/lib/utils/utils/logging.py
+++ b/core/lib/utils/utils/logging.py
@@ -1,8 +1,11 @@
 import logging
 import sys
+from typing import Any
 
 import structlog
 from structlog.types import EventDict, Processor
+from starlette_context import context
+from structlog.contextvars import bind_contextvars
 
 # https://github.com/hynek/structlog/issues/35#issuecomment-591321744
 # def rename_event_key(_, __, event_dict: EventDict) -> EventDict:
@@ -27,7 +30,8 @@ def drop_color_message_key(_, __, event_dict: EventDict) -> EventDict:
 
 def setup_logger():
     shared_processors: list[Processor] = [
-        structlog.threadlocal.merge_threadlocal,
+        # structlog.threadlocal.merge_threadlocal,
+        structlog.contextvars.merge_contextvars,
         drop_color_message_key,
         structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S"),
         structlog.processors.dict_tracebacks,
@@ -86,3 +90,11 @@ def setup_logger():
         root_logger.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
 
     sys.excepthook = handle_exception
+
+
+def bind_context_to_logger(var_dict: dict[str, Any]) -> None:
+    # bind to contextvars for local route use
+    bind_contextvars(**var_dict)
+    # doesn't like update with context |= {} syntax
+    # bind to context for middleware use
+    context.update(var_dict)

--- a/deployments/apiv2/services/mantarray/src/main.py
+++ b/deployments/apiv2/services/mantarray/src/main.py
@@ -5,8 +5,9 @@ from fastapi import Depends, FastAPI, Path, Request, status, HTTPException, Resp
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 import semver
+from starlette_context import context, request_cycle_context
 import structlog
-from structlog.threadlocal import bind_threadlocal, clear_threadlocal
+from structlog.contextvars import bind_contextvars, clear_contextvars
 from uvicorn.protocols.utils import get_path_with_query_string
 
 from auth import ProtectedAny, Scopes
@@ -23,7 +24,7 @@ from models.models import (
     LatestVersionsResponse,
 )
 from utils.db import AsyncpgPoolDep
-from utils.logging import setup_logger
+from utils.logging import setup_logger, bind_context_to_logger
 from utils.s3 import generate_presigned_post
 
 setup_logger()
@@ -47,7 +48,7 @@ asyncpg_pool = AsyncpgPoolDep(dsn=DATABASE_URL)
 async def db_session_middleware(request: Request, call_next) -> Response:
     request.state.pgpool = await asyncpg_pool()
     # clear previous request variables
-    clear_threadlocal()
+    clear_contextvars()
     # get request details for logging
     if (client_ip := request.headers.get("X-Forwarded-For")) is None:
         client_ip = f"{request.client.host}:{request.client.port}"
@@ -58,18 +59,20 @@ async def db_session_middleware(request: Request, call_next) -> Response:
     start_time = time.perf_counter_ns()
 
     # bind details to logger
-    bind_threadlocal(url=str(request.url), method=http_method, client_ip=client_ip)
+    bind_contextvars(url=str(request.url), method=http_method, client_ip=client_ip)
 
-    response = await call_next(request)
+    with request_cycle_context({}):
+        response = await call_next(request)
 
-    process_time = time.perf_counter_ns() - start_time
-    status_code = response.status_code
+        process_time = time.perf_counter_ns() - start_time
+        status_code = response.status_code
 
-    logger.info(
-        f"""{client_ip} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
-        status_code=status_code,
-        duration=process_time / 10**9,
-    )
+        logger.info(
+            f"""{client_ip} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
+            status_code=status_code,
+            duration=process_time / 10**9,
+            **context,
+        )
 
     return response
 
@@ -108,8 +111,12 @@ async def add_serial_number(
     token=Depends(ProtectedAny(scopes=[Scopes.MANTARRAY__SERIAL_NUMBER__EDIT])),
 ):
     try:
-        bind_threadlocal(
-            user_id=token.userid, customer_id=token.customer_id, serial_number=details.serial_number
+        bind_context_to_logger(
+            {
+                "user_id": token.userid,
+                "customer_id": token.customer_id,
+                "serial_number": details.serial_number,
+            }
         )
 
         async with request.state.pgpool.acquire() as con:
@@ -128,7 +135,9 @@ async def delete_serial_number(
     token=Depends(ProtectedAny(scopes=[Scopes.MANTARRAY__SERIAL_NUMBER__EDIT])),
 ):
     try:
-        bind_threadlocal(user_id=token.userid, customer_id=token.customer_id, serial_number=serial_number)
+        bind_context_to_logger(
+            {"user_id": token.userid, "customer_id": token.customer_id, "serial_number": serial_number}
+        )
 
         async with request.state.pgpool.acquire() as con:
             await con.execute("DELETE FROM MAUnits WHERE serial_number=$1", serial_number)
@@ -182,7 +191,7 @@ async def get_latest_versions(request: Request, serial_number: str, prod: bool):
 
 async def _get_latest_versions(request: Request, serial_number: str, prod: bool):
     """Get the latest SW, main FW, and channel FW versions compatible with the MA instrument with the given serial number."""
-    bind_threadlocal(serial_number=serial_number, is_prod_controller=prod)
+    bind_context_to_logger({"serial_number": serial_number, "is_prod_controller": prod})
 
     query = (
         "SELECT m.min_ma_controller_version, m.min_sting_controller_version, m.version AS main_fw_version, c.version AS channel_fw_version "
@@ -233,7 +242,7 @@ async def get_firmware_download_url(
     token=Depends(ProtectedAny(scopes=[Scopes.MANTARRAY__FIRMWARE__GET])),
 ):
     try:
-        bind_threadlocal(fw_type=fw_type, fw_version=version)
+        bind_context_to_logger({"fw_type": fw_type, "fw_version": version})
 
         url = get_fw_download_url(version, fw_type)
         return JSONResponse({"presigned_url": url})
@@ -251,7 +260,7 @@ async def upload_firmware_file(
     version: str = Path(..., regex=SEMVER_REGEX),
     token=Depends(ProtectedAny(scopes=[Scopes.MANTARRAY__FIRMWARE__EDIT])),
 ):
-    bind_threadlocal(fw_type=fw_type, fw_version=version)
+    bind_context_to_logger({"fw_type": fw_type, "fw_version": version})
 
     async with request.state.pgpool.acquire() as con:
         if fw_type == "main":
@@ -304,7 +313,7 @@ async def update_firmware_info(
     version: str = Path(..., regex=SEMVER_REGEX),
     token=Depends(ProtectedAny(scopes=[Scopes.MANTARRAY__FIRMWARE__EDIT])),
 ):
-    bind_threadlocal(fw_version=version)
+    bind_context_to_logger({"fw_version": version})
 
     # currently the only thing that needs to be updated through this route is the main FW version tied to a channel FW version
     try:
@@ -326,7 +335,7 @@ async def add_software_version(
     version: str = Path(..., regex=SEMVER_REGEX),
     token=Depends(ProtectedAny(scopes=[Scopes.MANTARRAY__SOFTWARE__EDIT])),
 ):
-    bind_threadlocal(controller_type=controller, sw_version=version)
+    bind_context_to_logger({"controller_type": controller, "sw_version": version})
 
     if controller == "mantarray":
         query = "INSERT INTO ma_controllers (version) VALUES ($1)"
@@ -336,6 +345,7 @@ async def add_software_version(
     try:
         async with request.state.pgpool.acquire() as con:
             await con.execute(query, version)
+
     except UniqueViolationError:
         pass  # TODO comment
     except Exception:

--- a/deployments/apiv2/services/mantarray/src/requirements.txt
+++ b/deployments/apiv2/services/mantarray/src/requirements.txt
@@ -17,3 +17,4 @@ psycopg2-binary==2.9.6
 httptools==0.5.0
 semver==3.0.2
 structlog==23.2.0
+starlette-context==0.3.6

--- a/deployments/apiv2/services/users/src/main.py
+++ b/deployments/apiv2/services/users/src/main.py
@@ -11,8 +11,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from jwt.exceptions import InvalidTokenError
 from fastapi_mail import FastMail, MessageSchema, ConnectionConfig, MessageType
 from pydantic import EmailStr
+from starlette_context import context, request_cycle_context
 import structlog
-from structlog.threadlocal import bind_threadlocal, clear_threadlocal
+from structlog.contextvars import bind_contextvars, clear_contextvars
 from uvicorn.protocols.utils import get_path_with_query_string
 
 from auth import (
@@ -51,7 +52,7 @@ from models.users import (
     PreferencesUpdate,
 )
 from utils.db import AsyncpgPoolDep
-from utils.logging import setup_logger
+from utils.logging import setup_logger, bind_context_to_logger
 from fastapi.templating import Jinja2Templates
 
 setup_logger()
@@ -78,7 +79,7 @@ async def db_session_middleware(request: Request, call_next) -> Response:
     request.state.pgpool = await asyncpg_pool()
 
     # clear previous request variables
-    clear_threadlocal()
+    clear_contextvars()
     # get request details for logging
     if (client_ip := request.headers.get("X-Forwarded-For")) is None:
         client_ip = f"{request.client.host}:{request.client.port}"
@@ -88,19 +89,20 @@ async def db_session_middleware(request: Request, call_next) -> Response:
     http_version = request.scope["http_version"]
     start_time = time.perf_counter_ns()
 
-    # bind details to logger
-    bind_threadlocal(url=str(request.url), method=http_method, client_ip=client_ip)
+    bind_contextvars(url=str(request.url), method=http_method, client_ip=client_ip)
 
-    response = await call_next(request)
+    with request_cycle_context({}):
+        response = await call_next(request)
 
-    process_time = time.perf_counter_ns() - start_time
-    status_code = response.status_code
+        process_time = time.perf_counter_ns() - start_time
+        status_code = response.status_code
 
-    logger.info(
-        f"""{client_ip} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
-        status_code=status_code,
-        duration=process_time / 10**9,
-    )
+        logger.info(
+            f"""{client_ip} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
+            status_code=status_code,
+            duration=process_time / 10**9,
+            **context,
+        )
 
     return response
 
@@ -125,7 +127,7 @@ async def login_customer(request: Request, details: CustomerLogin):
     email = details.email.lower()
     client_type = details.client_type if details.client_type else "unknown"
 
-    bind_threadlocal(client_type=client_type, email=email)
+    bind_context_to_logger({"client_type": client_type, "email": email})
 
     logger.info(f"Customer login attempt from client '{client_type}'")
 
@@ -144,7 +146,8 @@ async def login_customer(request: Request, details: CustomerLogin):
                 customer_id = select_query_result.get("id")
                 if select_query_result["password"] is None:
                     raise LoginError("Account needs verification")
-            bind_threadlocal(customer_id=str(customer_id))
+
+            bind_context_to_logger({"customer_id": str(customer_id)})
 
             pw = details.password.get_secret_value()
             # verify password, else raise LoginError
@@ -221,8 +224,10 @@ async def login_user(request: Request, details: UserLogin):
         )
 
     client_type = details.client_type if details.client_type else "unknown"
-    # bind relevant info to logger
-    bind_threadlocal(customer_id=str(customer_id), username=username, client_type=client_type)
+
+    bind_context_to_logger(
+        {"customer_id": str(customer_id), "username": username, "client_type": client_type}
+    )
 
     logger.info(f"User login attempt from client '{client_type}'")
 
@@ -235,7 +240,7 @@ async def login_user(request: Request, details: UserLogin):
                 user_id = select_query_result.get("id")
                 customer_id = select_query_result.get("customer_id")
                 # rebind customer id with uuid incase an alias was used above
-                bind_threadlocal(user_id=str(user_id), customer_id=str(customer_id))
+                bind_context_to_logger({"customer_id": str(customer_id), "user_id": str(user_id)})
 
             pw = details.password.get_secret_value()
 
@@ -352,7 +357,7 @@ async def refresh(request: Request, token=Depends(ProtectedAny(scopes=[Scopes.RE
     account_type = token.account_type
     is_customer_account = account_type == "customer"
 
-    bind_threadlocal(customer_id=token.customer_id, user_id=token.userid)
+    bind_context_to_logger({"customer_id": token.customer_id, "user_id": token.userid})
 
     if is_customer_account:
         select_query = "SELECT refresh_token FROM customers WHERE id=$1"
@@ -403,7 +408,7 @@ async def logout(request: Request, token=Depends(ProtectedAny(scopes=list(Scopes
     account_id = uuid.UUID(hex=token.account_id)
     is_customer_account = token.account_type == "customer"
 
-    bind_threadlocal(customer_id=token.customer_id, user_id=str(account_id))
+    bind_context_to_logger({"customer_id": token.customer_id, "user_id": str(account_id)})
 
     if is_customer_account:
         update_query = "UPDATE customers SET refresh_token = NULL WHERE id=$1"
@@ -441,8 +446,7 @@ async def register_customer(
                         json.dumps(dict(PULSE3D_PAID_USAGE)),
                     )
                     new_account_id = await con.fetchval(*insert_account_query_args)
-
-                    bind_threadlocal(customer_id=str(new_account_id), email=email)
+                    bind_context_to_logger({"customer_id": str(new_account_id), "email": email})
                 except UniqueViolationError as e:
                     if "customers_email_key" in str(e):
                         # Returning this message is currently ok since only the Curi customer account
@@ -495,8 +499,8 @@ async def register_user(
     try:
         email = details.email.lower()
         username = details.username.lower()
-        bind_threadlocal(customer_id=str(customer_id), email=email, username=username)
 
+        bind_context_to_logger({"customer_id": str(customer_id), "username": username, "email": email})
         check_prohibited_user_scopes(user_scopes, admin_scopes)
 
         logger.info(f"Registering new user with scopes: {user_scopes}")
@@ -513,7 +517,7 @@ async def register_user(
             async with con.transaction():
                 try:
                     new_account_id = await con.fetchval(*insert_account_query_args)
-                    bind_threadlocal(user_id=str(new_account_id))
+                    bind_context_to_logger({"user_id": str(new_account_id)})
                 except UniqueViolationError as e:
                     if "users_customer_id_name_key" in str(e):
                         # Returning this message is currently ok since duplicate usernames are only
@@ -587,8 +591,9 @@ async def email_account(
                 customer_id = row["id"]
                 username = None
 
-            bind_threadlocal(user_id=str(user_id), customer_id=str(customer_id), username=username)
-
+            bind_context_to_logger(
+                {"user_id": str(user_id), "customer_id": str(customer_id), "username": username}
+            )
             scope = convert_scope_str(f"{'user' if user else 'admin'}:{type}")
 
             await _create_account_email(
@@ -693,7 +698,7 @@ async def update_accounts(
         account_id = uuid.UUID(hex=token.account_id)
         customer_id = uuid.UUID(hex=token.customer_id)
 
-        bind_threadlocal(customer_id=token.customer_id, user_id=token.userid)
+        bind_context_to_logger({"customer_id": token.customer_id, "user_id": token.userid})
 
         is_customer = token.account_type == "customer"
         is_user = not is_customer
@@ -754,8 +759,10 @@ async def update_accounts(
                     else "UPDATE users SET verified='t', reset_token=NULL, password=$1, previous_passwords=array_prepend($1, previous_passwords[0:4]) WHERE id=$2 AND customer_id=$3"
                 )
                 query_params = [phash, account_id]
+
                 if is_user:
                     query_params.append(customer_id)
+
                 await con.execute(query, *query_params)
     except HTTPException:
         raise
@@ -772,7 +779,7 @@ async def get_all_users(request: Request, token=Depends(ProtectedAny(tag=ScopeTa
     """
     customer_id = uuid.UUID(hex=token.customer_id)
 
-    bind_threadlocal(customer_id=str(customer_id), user_id=None)
+    bind_context_to_logger({"customer_id": str(customer_id), "user_id": None})
 
     query = (
         "SELECT u.id, u.name, u.email, u.created_at, u.last_login, u.verified, u.suspended, u.reset_token, array_agg(s.scope) as scopes "
@@ -816,7 +823,7 @@ async def update_user_scopes(
     admin_scopes = token.scopes
     user_scopes = details.scopes
 
-    bind_threadlocal(customer_id=str(customer_id), user_id=str(account_id))
+    bind_context_to_logger({"customer_id": str(customer_id), "user_id": str(account_id)})
 
     try:
         check_prohibited_user_scopes(user_scopes, admin_scopes)
@@ -845,7 +852,7 @@ async def update_user_scopes(
 async def get_user_preferences(request: Request, token=Depends(ProtectedAny(tag=ScopeTags.PULSE3D_WRITE))):
     """Get preferences for user."""
     user_id = uuid.UUID(token.userid)
-    bind_threadlocal(customer_id=token.customer_id, user_id=str(user_id))
+    bind_context_to_logger({"customer_id": token.customer_id, "user_id": str(user_id)})
 
     try:
         async with request.state.pgpool.acquire() as con:
@@ -863,11 +870,13 @@ async def update_user_preferences(
 ):
     """Update a user's product preferences."""
     user_id = uuid.UUID(token.userid)
-    bind_threadlocal(
-        customer_id=token.customer_id,
-        user_id=str(user_id),
-        product=details.product,
-        preferences=details.changes,
+    bind_context_to_logger(
+        {
+            "customer_id": token.customer_id,
+            "user_id": str(user_id),
+            "product": details.product,
+            "preferences": details.changes,
+        }
     )
 
     try:
@@ -914,7 +923,7 @@ async def get_user(
 
         # this is only being set in case an error is raised later
         customer_id = self_id
-        bind_threadlocal(user_id=str(account_id), customer_id=str(customer_id))
+        bind_context_to_logger({"user_id": str(account_id), "customer_id": str(customer_id)})
     else:
         if not is_self_retrieval:
             raise HTTPException(
@@ -923,7 +932,7 @@ async def get_user(
             )
 
         customer_id = uuid.UUID(hex=token.customer_id)
-        bind_threadlocal(user_id=str(self_id), customer_id=str(customer_id))
+        bind_context_to_logger({"user_id": str(self_id), "customer_id": str(customer_id)})
 
         query = get_user_info_query
         query_args = (customer_id, account_id)
@@ -982,7 +991,7 @@ async def update_user(
     # TODO also need to check scope below once user self edit actions are added?
 
     if is_customer_account:
-        bind_threadlocal(user_id=str(account_id), customer_id=str(self_id), action=action)
+        bind_context_to_logger({"user_id": str(account_id), "customer_id": str(self_id), "action": action})
 
         if is_self_edit:
             if action == "set_alias":
@@ -1021,7 +1030,7 @@ async def update_user(
                 )
     else:
         # TODO unit test this else branch
-        bind_threadlocal(user_id=str(self_id), customer_id=token.customer_id, action=action)
+        bind_context_to_logger({"user_id": str(self_id), "customer_id": token.customer_id, "action": action})
 
         if not is_self_edit:
             raise HTTPException(

--- a/deployments/apiv2/services/users/src/requirements.txt
+++ b/deployments/apiv2/services/users/src/requirements.txt
@@ -19,3 +19,4 @@ httptools==0.5.0
 httpx==0.24.0
 aioredis==2.0.1
 structlog==23.2.0
+starlette-context==0.3.6

--- a/deployments/pulse3d/services/pulse3d/src/main.py
+++ b/deployments/pulse3d/services/pulse3d/src/main.py
@@ -37,9 +37,10 @@ from pulse3D.constants import (
 )
 from semver import VersionInfo
 from stream_zip import ZIP_64, stream_zip
-from structlog.threadlocal import bind_threadlocal, clear_threadlocal
+from starlette_context import context, request_cycle_context
+from structlog.contextvars import bind_contextvars, clear_contextvars
 from utils.db import AsyncpgPoolDep
-from utils.logging import setup_logger
+from utils.logging import setup_logger, bind_context_to_logger
 from utils.s3 import S3Error, generate_presigned_post, generate_presigned_url, upload_file_to_s3
 from uvicorn.protocols.utils import get_path_with_query_string
 
@@ -77,7 +78,7 @@ app.add_middleware(
 async def db_session_middleware(request: Request, call_next) -> Response:
     request.state.pgpool = await asyncpg_pool()
     # clear previous request variables
-    clear_threadlocal()
+    clear_contextvars()
     # get request details for logging
     if (client_ip := request.headers.get("X-Forwarded-For")) is None:
         client_ip = f"{request.client.host}:{request.client.port}"
@@ -88,18 +89,20 @@ async def db_session_middleware(request: Request, call_next) -> Response:
     start_time = time.perf_counter_ns()
 
     # bind details to logger
-    bind_threadlocal(url=str(request.url), method=http_method, client_ip=client_ip)
+    bind_contextvars(url=str(request.url), method=http_method, client_ip=client_ip)
 
-    response = await call_next(request)
+    with request_cycle_context({}):
+        response = await call_next(request)
 
-    process_time = time.perf_counter_ns() - start_time
-    status_code = response.status_code
+        process_time = time.perf_counter_ns() - start_time
+        status_code = response.status_code
 
-    logger.info(
-        f"""{client_ip} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
-        status_code=status_code,
-        duration=process_time / 10**9,
-    )
+        logger.info(
+            f"""{client_ip} - "{http_method} {url} HTTP/{http_version}" {status_code}""",
+            status_code=status_code,
+            duration=process_time / 10**9,
+            **context,
+        )
 
     return response
 
@@ -125,10 +128,9 @@ async def get_info_of_uploads(
         account_type = token.account_type
         is_user = account_type == "user"
 
-        if is_user:
-            bind_threadlocal(user_id=account_id, customer_id=token.customer_id, upload_ids=upload_ids)
-        else:
-            bind_threadlocal(user_id=None, customer_id=account_id, upload_ids=upload_ids)
+        bind_context_to_logger(
+            {"user_id": token.userid, "customer_id": token.customer_id, "upload_ids": upload_ids}
+        )
 
         # give advanced privileges to access all uploads under customer_id
         # TODO update this to product specific when landing page is specced out more
@@ -169,8 +171,13 @@ async def create_recording_upload(
         upload_type = details.upload_type if details.upload_type != "pulse3d" else "mantarray"
         check_prohibited_product(token.scopes, upload_type)
 
-        bind_threadlocal(
-            user_id=user_id, customer_id=customer_id, upload_id=str(upload_id), upload_type=upload_type
+        bind_context_to_logger(
+            {
+                "user_id": user_id,
+                "customer_id": customer_id,
+                "upload_id": str(upload_id),
+                "upload_type": upload_type,
+            }
         )
 
         upload_params = {
@@ -221,7 +228,9 @@ async def soft_delete_uploads(
     try:
         account_id = str(uuid.UUID(token.account_id))
 
-        bind_threadlocal(user_id=token.userid, customer_id=token.customer_id, upload_ids=upload_ids)
+        bind_context_to_logger(
+            {"user_id": token.userid, "customer_id": token.customer_id, "upload_ids": upload_ids}
+        )
 
         async with request.state.pgpool.acquire() as con:
             await delete_uploads(
@@ -246,12 +255,10 @@ async def download_zip_files(
     upload_ids = [str(id) for id in upload_ids]
     account_id = str(uuid.UUID(token.account_id))
     account_type = token.account_type
-    is_user = account_type == "user"
 
-    if is_user:
-        bind_threadlocal(user_id=account_id, customer_id=token.customer_id, upload_ids=upload_ids)
-    else:
-        bind_threadlocal(user_id=None, customer_id=account_id, upload_ids=upload_ids)
+    bind_context_to_logger(
+        {"user_id": token.userid, "customer_id": token.customer_id, "upload_ids": upload_ids}
+    )
 
     # give advanced privileges to access all uploads under customer_id
     if Scopes.MANTARRAY__RW_ALL_DATA in token.scopes:
@@ -295,7 +302,7 @@ async def create_log_upload(
         customer_id = str(uuid.UUID(token.customer_id))
         s3_key = f"{customer_id}/{user_id}"
 
-        bind_threadlocal(customer_id=customer_id, user_id=user_id)
+        bind_context_to_logger({"customer_id": customer_id, "user_id": user_id})
 
         params = _generate_presigned_post(details, MANTARRAY_LOGS_BUCKET, s3_key)
         return UploadResponse(params=params)
@@ -331,7 +338,9 @@ async def get_info_of_jobs(
         account_type = token.account_type
         is_user = account_type == "user"
 
-        bind_threadlocal(user_id=token.userid, customer_id=token.customer_id, job_ids=job_ids)
+        bind_context_to_logger(
+            {"user_id": token.userid, "customer_id": token.customer_id, "job_ids": job_ids}
+        )
 
         async with request.state.pgpool.acquire() as con:
             jobs = await _get_jobs(con, token, job_ids)
@@ -409,7 +418,7 @@ async def create_new_job(
         user_scopes = token.scopes
         upload_id = details.upload_id
 
-        bind_threadlocal(user_id=user_id, customer_id=customer_id, upload_id=str(upload_id))
+        bind_context_to_logger({"user_id": user_id, "customer_id": customer_id, "upload_id": str(upload_id)})
 
         logger.info(f"Creating job for upload {upload_id} with user ID: {user_id}")
 
@@ -429,7 +438,7 @@ async def create_new_job(
             VersionInfo.parse(details.previous_version) if details.previous_version else None
         )
 
-        bind_threadlocal(version=details.version)
+        bind_context_to_logger({"version": details.version})
 
         pulse3d_semver = VersionInfo.parse(details.version)
         use_noise_based_peak_finding = pulse3d_semver >= "0.33.2"
@@ -542,7 +551,7 @@ async def create_new_job(
                 job_type=upload_type,
             )
 
-            bind_threadlocal(job_id=str(job_id))
+            bind_context_to_logger({"job_id": str(job_id)})
 
             # check customer quota after job
             usage_quota = await check_customer_quota(con, customer_id, upload_type)
@@ -632,7 +641,9 @@ async def soft_delete_jobs(
     try:
         account_id = str(uuid.UUID(token.account_id))
 
-        bind_threadlocal(user_id=token.userid, customer_id=token.customer_id, job_ids=job_ids)
+        bind_context_to_logger(
+            {"user_id": token.userid, "customer_id": token.customer_id, "job_ids": job_ids}
+        )
 
         async with request.state.pgpool.acquire() as con:
             await delete_jobs(
@@ -655,7 +666,7 @@ async def download_analyses(
     # need to convert UUIDs to str to avoid issues with DB
     job_ids = [str(job_id) for job_id in job_ids]
 
-    bind_threadlocal(user_id=token.userid, customer_id=token.customer_id, job_ids=job_ids)
+    bind_context_to_logger({"user_id": token.userid, "customer_id": token.customer_id, "job_ids": job_ids})
 
     try:
         async with request.state.pgpool.acquire() as con:
@@ -728,12 +739,9 @@ async def get_interactive_waveform_data(
     upload_id = str(upload_id)
     job_id = str(job_id)
 
-    if is_user:
-        bind_threadlocal(
-            customer_id=token.customer_id, user_id=account_id, upload_id=upload_id, job_id=job_id
-        )
-    else:
-        bind_threadlocal(user_id=None, customer_id=account_id, upload_id=upload_id, job_id=job_id)
+    bind_context_to_logger(
+        {"customer_id": token.customer_id, "user_id": token.userid, "upload_id": upload_id, "job_id": job_id}
+    )
 
     try:
         async with request.state.pgpool.acquire() as con:
@@ -826,7 +834,7 @@ async def get_usage_quota(
     try:
         customer_id = str(uuid.UUID(token.customer_id))
 
-        bind_threadlocal(customer_id=customer_id)
+        bind_context_to_logger({"customer_id": customer_id})
 
         async with request.state.pgpool.acquire() as con:
             usage_quota = await check_customer_quota(con, customer_id, service)
@@ -844,7 +852,7 @@ async def save_analysis_presets(
     try:
         user_id = str(uuid.UUID(token.userid))
         customer_id = str(uuid.UUID(token.customer_id))
-        bind_threadlocal(customer_id=customer_id, user_id=user_id)
+        bind_context_to_logger({"customer_id": customer_id, "user_id": user_id})
 
         async with request.state.pgpool.acquire() as con:
             return await create_analysis_preset(con, user_id, details)
@@ -859,7 +867,7 @@ async def get_analysis_presets(request: Request, token=Depends(ProtectedAny(tag=
     try:
         user_id = str(uuid.UUID(token.userid))
         customer_id = str(uuid.UUID(token.customer_id))
-        bind_threadlocal(customer_id=customer_id, user_id=user_id)
+        bind_context_to_logger({"customer_id": customer_id, "user_id": user_id})
 
         async with request.state.pgpool.acquire() as con:
             async with con.transaction():

--- a/deployments/pulse3d/services/pulse3d/src/requirements.txt
+++ b/deployments/pulse3d/services/pulse3d/src/requirements.txt
@@ -16,4 +16,4 @@ fastparquet==2023.4.0
 pyarrow==12.0.0
 semver==2.13.0
 structlog==23.2.0
-
+starlette-context==0.3.6

--- a/frontend/pulse3d/src/components/basicWidgets/ButtonWidget.js
+++ b/frontend/pulse3d/src/components/basicWidgets/ButtonWidget.js
@@ -1,0 +1,66 @@
+import styled from "styled-components";
+import CircularSpinner from "./CircularSpinner";
+const Button = styled.button(
+  ({ props }) => `
+  background-color: ${props.backgroundColor || "var(--dark-blue)"};
+  color: ${props.color || "var(--light-gray)"};
+  font-size: inherit;
+  border: none;
+  width: 100%;
+  height: 100%;
+  position: ${props.position || "inherit"};
+  border-radius: ${props.borderRadius || "0px"};
+  font-size: ${props.fontSize || "18px"};
+  box-shadow: 3px 3px 3px 0px rgb(0 0 0 / 30%), 7px 7px 7px 0px rgb(0 0 0 / 10%);
+  &:hover {
+    background-color: ${props.disabled || "var(--teal-green)"};
+    cursor:${props.disabled || "pointer"};
+  }
+  `
+);
+
+const ProgressSpinner = styled.div(
+  ({ props }) => `
+  position: absolute;
+  align-items: center;
+  display: flex;
+  justify-self: center;
+  height: ${props.height || "60px"};
+  align-items: center;
+`
+);
+
+const Container = styled.div(
+  ({ props }) => `
+  display: flex;
+  justify-content: center;
+  position: relative;
+  width: ${props.width || "100%"};
+  height: ${props.height || "60px"};
+  top: ${props.top || "0px"};
+  left: ${props.left || "0px"};
+`
+);
+
+// TODO should this automatically disable itself if props.inProgress === true ?
+const ButtonWidget = (props) => {
+  return (
+    <Container props={props}>
+      <Button
+        onClick={() => {
+          if (!props.isSelected && !props.disabled) props.clickFn(props.label); // only if not already selected and enabled, emit event
+        }}
+        props={props}
+      >
+        {props.label}
+      </Button>{" "}
+      {props.inProgress && (
+        <ProgressSpinner props={props}>
+          <CircularSpinner />
+        </ProgressSpinner>
+      )}
+    </Container>
+  );
+};
+
+export default ButtonWidget;


### PR DESCRIPTION
`We` were using threadlocal module in structlog (https://www.structlog.org/en/23.2.0/thread-local.html) to manage binding of relevant request variables (eg customer id, user id, upload/job ids, ....) to the logger, which is now deprecated in favor of context module (https://www.structlog.org/en/stable/contextvars.html).

With this change as is, context variables bound in the request handler are not available to middleware handler which needs them. (see example https://github.com/tiangolo/fastapi/issues/4696).
There is also now a relevant warning in the structlog docs itself for fastapi:

```
Since the storage mechanics of your context variables is different for each concurrency method, they are isolated from each other.

This can be a problem in hybrid applications like those based on [starlette](https://www.starlette.io/) (this [includes FastAPI](https://github.com/tiangolo/fastapi/discussions/5999)) where context variables set in a synchronous context don’t appear in logs from an async context and vice versa.
```

The fix in this pr uses `startlette-context` to manage context through entire request-response cycle to store relevant request variables for use in the middleware logs and exceptions. 

