### PR TITLE
Add LoginType to customers and users tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ core/db/**/.env*
 build/
 *.egg-info
 .pytest_cache
+.idea
+.run
 .vscode
 **/public/serviceWorker.js
 **.coverage

--- a/core/db/curibio/alembic/versions/86bd61c49403_addlogintypetocustomersandusers.py
+++ b/core/db/curibio/alembic/versions/86bd61c49403_addlogintypetocustomersandusers.py
@@ -1,17 +1,18 @@
 """addLoginTypeToCustomersAndUsers
 
 Revision ID: 86bd61c49403
-Revises: 848fb69a8766
+Revises: 7a11f7e9da9b
 Create Date: 2024-05-21 10:51:30.168752
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '86bd61c49403'
-down_revision = '848fb69a8766'
+revision = "86bd61c49403"
+down_revision = "7a11f7e9da9b"
 branch_labels = None
 depends_on = None
 login_types = ("password", "sso_microsoft")
@@ -29,7 +30,7 @@ def upgrade():
                 sa.Enum(*login_types, name="LoginType"),
                 server_default=login_types[0],
                 nullable=False,
-            )
+            ),
         )
 
 

--- a/core/db/curibio/alembic/versions/86bd61c49403_addlogintypetocustomersandusers.py
+++ b/core/db/curibio/alembic/versions/86bd61c49403_addlogintypetocustomersandusers.py
@@ -1,0 +1,40 @@
+"""addLoginTypeToCustomersAndUsers
+
+Revision ID: 86bd61c49403
+Revises: 848fb69a8766
+Create Date: 2024-05-21 10:51:30.168752
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '86bd61c49403'
+down_revision = '848fb69a8766'
+branch_labels = None
+depends_on = None
+login_types = ("password", "sso_microsoft")
+tables = ("customers", "users")
+
+
+def upgrade():
+    op.execute(f'CREATE TYPE "LoginType" AS ENUM {login_types}')
+
+    for table in tables:
+        op.add_column(
+            table,
+            sa.Column(
+                "login_type",
+                sa.Enum(*login_types, name="LoginType"),
+                server_default=login_types[0],
+                nullable=False,
+            )
+        )
+
+
+def downgrade():
+    for table in tables:
+        op.drop_column(table, "login_type")
+
+    op.execute('DROP TYPE "LoginType" CASCADE')

--- a/core/db/curibio/requirements.txt
+++ b/core/db/curibio/requirements.txt
@@ -1,0 +1,10 @@
+alembic==1.13.1
+argon2-cffi==23.1.0
+argon2-cffi-bindings==21.2.0
+cffi==1.16.0
+Mako==1.3.5
+MarkupSafe==2.1.5
+psycopg2-binary==2.9.9
+pycparser==2.22
+SQLAlchemy==2.0.30
+typing_extensions==4.11.0


### PR DESCRIPTION
Hey guys,

As discussed, I'm adding a `LoginType` column to both the customers and users tables.  curi_admin will decide the `LoginType` when creating new customers, and new customers will log in using that method, and by default will create users with that `LoginType`.  This allows us to grant exceptions per organization if needed (e.g. curi people want to sso), instead of making `LoginType` a global organizational setting.

I'm adding a `requirements.txt` to core/db/curibio since we didn't have one.  This `requirements.txt` is the result of pip-installing `alembic`, `argon2-cffi`, and `psycopg2-binary`, which was all that was needed to actually run the migrations against a local docker postgres db.

Please let me know what you guys think.  Thanks!
