### PR TITLE
Hide front-end password-related components for SSO users

### DIFF
--- a/deployments/apiv2/services/users/src/main.py
+++ b/deployments/apiv2/services/users/src/main.py
@@ -682,14 +682,16 @@ async def register_user(
                     select_customer_login_type_query = ("SELECT login_type FROM customers WHERE id=$1", customer_id)
                     customer_login_type = await con.fetchval(*select_customer_login_type_query)
 
-                    # suspended and verified get set to False by default
-                    # for SSO, we interpret verified as email-verified and we still set it to False since it's moot
+                    # suspended gets set to False by default
+                    # verified gets set to False for password users and to True for SSO users
                     insert_account_query_args = (
-                        "INSERT INTO users (name, email, customer_id, login_type) VALUES ($1, $2, $3, $4) RETURNING id",
+                        "INSERT INTO users (name, email, customer_id, login_type, verified) "
+                        "VALUES ($1, $2, $3, $4, $5) RETURNING id",
                         username,
                         email,
                         customer_id,
-                        customer_login_type
+                        customer_login_type,
+                        customer_login_type != LoginType.PASSWORD
                     )
 
                     new_account_id = await con.fetchval(*insert_account_query_args)

--- a/deployments/apiv2/services/users/tests/test_main.py
+++ b/deployments/apiv2/services/users/tests/test_main.py
@@ -660,11 +660,13 @@ def test_register__user__success(special_char, mocked_asyncpg_con, mocker):
             test_customer_id
         ),
         mocker.call(
-            "INSERT INTO users (name, email, customer_id, login_type) VALUES ($1, $2, $3, $4) RETURNING id",
+            "INSERT INTO users (name, email, customer_id, login_type, verified) "
+            "VALUES ($1, $2, $3, $4, $5) RETURNING id",
             registration_details["username"].lower(),
             registration_details["email"].lower(),
             test_customer_id,
-            "password"
+            "password",
+            False
         )
     ])
     mocked_asyncpg_con.execute.assert_called_once_with(
@@ -710,11 +712,13 @@ def test_register__user__sso__success(mocked_asyncpg_con, mocker):
             test_customer_id
         ),
         mocker.call(
-            "INSERT INTO users (name, email, customer_id, login_type) VALUES ($1, $2, $3, $4) RETURNING id",
+            "INSERT INTO users (name, email, customer_id, login_type, verified) "
+            "VALUES ($1, $2, $3, $4, $5) RETURNING id",
             registration_details["username"].lower(),
             registration_details["email"].lower(),
             test_customer_id,
-            "sso_microsoft"
+            "sso_microsoft",
+            True
         )
     ])
     mocked_asyncpg_con.execute.assert_called_once_with(

--- a/frontend/pulse3d/src/pages/account-settings.js
+++ b/frontend/pulse3d/src/pages/account-settings.js
@@ -98,7 +98,7 @@ const ButtonContainer = styled.div`
 const isEmpty = (str) => str === undefined || str.length === 0;
 
 export default function AccountSettings() {
-  const { accountType, usageQuota, accountId, productPage, preferences } = useContext(AuthContext);
+  const { accountType, loginType, usageQuota, accountId, productPage, preferences } = useContext(AuthContext);
   const { pulse3dVersions, metaPulse3dVersions } = useContext(UploadsContext);
   const [jobsLimit, setJobsLimit] = useState(-1);
   const [currentJobUsage, setCurrentJobUsage] = useState(0);
@@ -110,6 +110,7 @@ export default function AccountSettings() {
   const [passwords, setPasswords] = useState({ password1: "", password2: "" });
 
   const isAdminAccount = accountType === "admin";
+  const isPasswordAccount = loginType === "password"
 
   useEffect(() => {
     if (usageQuota && usageQuota.limits && usageQuota.current) {
@@ -170,39 +171,41 @@ export default function AccountSettings() {
   return (
     <BackgroundContainer>
       <Header>Account Settings</Header>
-      <SubsectionContainer>
-        <Subheader>Change Password</Subheader>
-        <SubSectionBody>
-          <PasswordContainer>
-            <PasswordForm
-              password1={passwords.password1}
-              password2={passwords.password2}
-              onChangePassword={onChangePassword}
-              setErrorMsg={setErrorMsg}
-            ></PasswordForm>
-          </PasswordContainer>
-          <ButtonContainer>
-            {passwordUpdateSuccess && <SuccessText>Update Successful!</SuccessText>}
-            {errorMsg && <ErrorText role="errorMsg">{errorMsg}</ErrorText>}
-            <ButtonWidget
-              width="150px"
-              height="40px"
-              position="relative"
-              borderRadius="3px"
-              label="Save"
-              backgroundColor={
-                inProgress.password ||
-                !(isEmpty(errorMsg) && !isEmpty(passwords.password1) && !isEmpty(passwords.password2))
-                  ? "var(--dark-gray)"
-                  : "var(--dark-blue)"
-              }
-              inProgress={inProgress.password}
-              disabled={inProgress.password}
-              clickFn={saveNewPassword}
-            />
-          </ButtonContainer>
-        </SubSectionBody>
-      </SubsectionContainer>
+      {isPasswordAccount && (
+        <SubsectionContainer>
+          <Subheader>Change Password</Subheader>
+          <SubSectionBody>
+            <PasswordContainer>
+              <PasswordForm
+                password1={passwords.password1}
+                password2={passwords.password2}
+                onChangePassword={onChangePassword}
+                setErrorMsg={setErrorMsg}
+              ></PasswordForm>
+            </PasswordContainer>
+            <ButtonContainer>
+              {passwordUpdateSuccess && <SuccessText>Update Successful!</SuccessText>}
+              {errorMsg && <ErrorText role="errorMsg">{errorMsg}</ErrorText>}
+              <ButtonWidget
+                width="150px"
+                height="40px"
+                position="relative"
+                borderRadius="3px"
+                label="Save"
+                backgroundColor={
+                  inProgress.password ||
+                  !(isEmpty(errorMsg) && !isEmpty(passwords.password1) && !isEmpty(passwords.password2))
+                    ? "var(--dark-gray)"
+                    : "var(--dark-blue)"
+                }
+                inProgress={inProgress.password}
+                disabled={inProgress.password}
+                clickFn={saveNewPassword}
+              />
+            </ButtonContainer>
+          </SubSectionBody>
+        </SubsectionContainer>
+      )}
       {!isAdminAccount && (
         <SubsectionContainer>
           <UserPreferences


### PR DESCRIPTION
Hey guys,

As the title says:

SSO users don't see the "Change Password" component in "Account Settings"

<img width="1588" alt="Screenshot 2024-06-06 at 9 46 37 AM" src="https://github.com/CuriBio/k8s_curi/assets/167813555/a8a382a5-84f2-42be-891a-07aaf4a4224b">

I also backtracked a little; new SSO users now get verified=True.  That way, Admins viewing the "User Info" section still get valuable info in the Status column (active or suspended), but by having verified=True from the beginning, the Status column will never show the "needs verification" link that displays a "Please enter a new password" modal.

<img width="1588" alt="Screenshot 2024-06-06 at 9 46 09 AM" src="https://github.com/CuriBio/k8s_curi/assets/167813555/c59a8da5-44e4-4221-8adc-c5a28244e4d3">

Please let me know what you guys think.  Thanks!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207488987684450