### PR TITLE
Change /email endpoint to not send verify or reset emails for sso users

### DIFF
--- a/deployments/apiv2/services/users/src/main.py
+++ b/deployments/apiv2/services/users/src/main.py
@@ -774,14 +774,14 @@ async def email_account(
     try:
         async with request.state.pgpool.acquire() as con:
             query = (
-                "SELECT id, customer_id, name FROM users WHERE email=$1"
+                "SELECT id, customer_id, name FROM users WHERE email=$1 AND login_type=$2"
                 if user
-                else "SELECT id FROM customers WHERE email=$1"
+                else "SELECT id FROM customers WHERE email=$1 AND login_type=$2"
             )
 
-            row = await con.fetchrow(query, email)
+            row = await con.fetchrow(query, email, LoginType.PASSWORD)
 
-            # send email if found, otherwise return 204, doesn't need to raise an exception
+            # send email if found and password-based user, otherwise return 204, doesn't need to raise an exception
             if row is None:
                 return
 

--- a/frontend/pulse3d/src/pages/login.js
+++ b/frontend/pulse3d/src/pages/login.js
@@ -323,7 +323,7 @@ export default function Login() {
         labels={
           emailSent
             ? [
-                "If there's an account associated with that email, we've sent a link to reset the password.",
+                "If there's a password-based account associated with that email, we've sent a link to reset the password.",
                 "Please check your inbox.",
               ]
             : []


### PR DESCRIPTION
Hey guys,

Just a small change to ensure that we don't send password-related emails to sso users.

I tested this locally and it worked, and the change didn't trigger any extra test errors.

Please take a look when you have a minute.  Thanks!