### PR TITLE
Change admin registration to also take sso_organization and sso_admin_org_id

### DIFF
--- a/core/db/curibio/alembic/versions/90ec0862fdde_addorganizationandadminorgidtocustomers.py
+++ b/core/db/curibio/alembic/versions/90ec0862fdde_addorganizationandadminorgidtocustomers.py
@@ -1,0 +1,33 @@
+"""addOrganizationAndAdminOrgIdToCustomers
+
+Revision ID: 90ec0862fdde
+Revises: 1fb818f900b6
+Create Date: 2024-06-14 10:16:47.032714
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "90ec0862fdde"
+down_revision = "1fb818f900b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE customers ADD COLUMN sso_organization VARCHAR(256)")
+    op.execute("ALTER TABLE customers ADD COLUMN sso_admin_org_id VARCHAR(256)")
+    op.execute(
+        "ALTER TABLE customers ADD CONSTRAINT customers_sso_organization_key UNIQUE (sso_organization)"
+    )
+    op.execute(
+        "ALTER TABLE customers ADD CONSTRAINT customers_sso_admin_org_id_key UNIQUE (sso_admin_org_id)"
+    )
+
+
+def downgrade():
+    op.execute("ALTER TABLE customers DROP CONSTRAINT customers_sso_admin_org_id_key")
+    op.execute("ALTER TABLE customers DROP CONSTRAINT customers_sso_organization_key")
+    op.execute("ALTER TABLE customers DROP COLUMN sso_admin_org_id")
+    op.execute("ALTER TABLE customers DROP COLUMN sso_organization")

--- a/deployments/apiv2/services/users/src/models/users.py
+++ b/deployments/apiv2/services/users/src/models/users.py
@@ -67,6 +67,8 @@ class AdminCreate(ScopeConverter):
     email: EmailStr
     scopes: list[Scopes]
     login_type: LoginType = Field(default=LoginType.PASSWORD)
+    sso_organization: str | None = Field(default=None)
+    sso_admin_org_id: str | None = Field(default=None)
 
 
 class UserCreate(ScopeConverter):

--- a/deployments/apiv2/services/users/tests/test_main.py
+++ b/deployments/apiv2/services/users/tests/test_main.py
@@ -893,10 +893,13 @@ def test_register__admin__success(mocked_asyncpg_con, spied_pw_hasher, mocker):
     }
 
     mocked_asyncpg_con.fetchval.assert_called_once_with(
-        "INSERT INTO customers (email, usage_restrictions, login_type) VALUES ($1, $2, $3) RETURNING id",
+        "INSERT INTO customers (email, usage_restrictions, login_type, sso_organization, sso_admin_org_id) "
+        "VALUES ($1, $2, $3, $4, $5) RETURNING id",
         registration_details["email"].lower(),
         json.dumps(dict(PULSE3D_PAID_USAGE)),
         "password",
+        None,
+        None,
     )
     mocked_asyncpg_con.execute.assert_called_once_with(
         "INSERT INTO account_scopes VALUES ($1, NULL, unnest($2::text[]))", test_user_id, expected_scopes
@@ -909,10 +912,10 @@ def test_register__admin__login_type_sso_microsoft_success(mocked_asyncpg_con, s
     expected_scopes = [Scopes.MANTARRAY__ADMIN, Scopes.NAUTILAI__ADMIN]
     registration_details = {
         "email": "tEsT@email.com",
-        "password1": TEST_PASSWORD,
-        "password2": TEST_PASSWORD,
         "scopes": expected_scopes,
         "login_type": "sso_microsoft",
+        "sso_organization": "some-organization",
+        "sso_admin_org_id": "some-admin-org-id",
     }
 
     test_user_id = uuid.uuid4()
@@ -934,10 +937,13 @@ def test_register__admin__login_type_sso_microsoft_success(mocked_asyncpg_con, s
     }
 
     mocked_asyncpg_con.fetchval.assert_called_once_with(
-        "INSERT INTO customers (email, usage_restrictions, login_type) VALUES ($1, $2, $3) RETURNING id",
+        "INSERT INTO customers (email, usage_restrictions, login_type, sso_organization, sso_admin_org_id) "
+        "VALUES ($1, $2, $3, $4, $5) RETURNING id",
         registration_details["email"].lower(),
         json.dumps(dict(PULSE3D_PAID_USAGE)),
         "sso_microsoft",
+        "some-organization",
+        "some-admin-org-id",
     )
     mocked_asyncpg_con.execute.assert_called_once_with(
         "INSERT INTO account_scopes VALUES ($1, NULL, unnest($2::text[]))", test_user_id, expected_scopes


### PR DESCRIPTION
Hey guys,

I'm changing admin registration to also take `sso_organization` and `sso_admin_org_id`.  This includes:
- new DB columns
- FE changes to send either (`password`, `none`, `none`) or (`sso_microsoft`, `$sso_organization`, `$sso_admin_org_id`)
- similar BE changes to handle both scenarions

I went with VARCHAR(256) for the new DB columns since google can return a full domain for sso_organization and their ids can also be 255 chars.

Please take a look when you have a minute.  Thanks!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207577433074861