### PR TITLE
Disable Notifications server-side rendering

### DIFF
--- a/frontend/pulse3d/src/components/editor/DOMPurifyDiv.js
+++ b/frontend/pulse3d/src/components/editor/DOMPurifyDiv.js
@@ -1,0 +1,9 @@
+import DOMPurify from "dompurify";
+
+export default function DOMPurifyDiv({ rawHTML }) {
+  return (
+    <div className="ql-editor">
+      <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(rawHTML) }} />
+    </div>
+  );
+}

--- a/frontend/pulse3d/src/components/editor/Editor.js
+++ b/frontend/pulse3d/src/components/editor/Editor.js
@@ -1,11 +1,6 @@
+import Quill from "quill";
 import { forwardRef, useEffect, useRef } from "react";
 import "quill/dist/quill.snow.css";
-import dynamic from "next/dynamic";
-
-const Quill = dynamic(import("quill"), {
-  ssr: false,
-  loading: () => <p>Loading...</p>,
-});
 
 // Editor is an uncontrolled React component
 // TODO make this component NOT server-side-rendered, so page refresh doesn't fail

--- a/frontend/pulse3d/src/components/editor/WrappedEditor.js
+++ b/frontend/pulse3d/src/components/editor/WrappedEditor.js
@@ -1,0 +1,5 @@
+import Editor from "./Editor";
+
+export default function WrappedEditor({ editorRef, ...props }) {
+  return <Editor {...props} ref={editorRef} />;
+}


### PR DESCRIPTION
Trying to fix the issues we're having with Quill (fail on refresh, webpack(?))and DOMPurify by disabling server-side rendering.

Took some ideas from [stack overflow](https://stackoverflow.com/questions/63469232/forwardref-error-when-dynamically-importing-a-module-in-next-js) and [other places](https://sentry.io/answers/using-dangerouslysetinnerhtml-in-next-js/).



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208065885903027