### PR TITLE
Create notification_messages endpoint

### DIFF
--- a/deployments/pulse3d/services/pulse3d/src/main.py
+++ b/deployments/pulse3d/services/pulse3d/src/main.py
@@ -80,6 +80,7 @@ from models.models import (
     JobRequest,
     GetJobsInfoRequest,
     JobResponse,
+    NotificationMessageResponse,
     NotificationResponse,
     SaveNotificationRequest,
     SaveNotificationResponse,
@@ -944,6 +945,22 @@ async def delete_analysis_preset(
 
     except Exception:
         logger.exception(f"Failed to delete analysis preset {preset_name} for user")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@app.get("/notification_messages", response_model=list[NotificationMessageResponse])
+async def get_notification_messages(
+    notification_message_id: uuid.UUID = Query(None), token=Depends(ProtectedAny(tag=ScopeTags.PULSE3D_READ))
+):
+    """Get info for user|customer notification messages."""
+    try:
+        account_id = str(uuid.UUID(token.account_id))
+        nm_id = str(notification_message_id) if notification_message_id else None
+        bind_context_to_logger({"account_id": account_id})
+        response = await notification_service.get_notification_messages(account_id, nm_id)  # noqa: F821
+        return response
+    except Exception:
+        logger.exception("Failed to get notification messages")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 

--- a/deployments/pulse3d/services/pulse3d/src/models/models.py
+++ b/deployments/pulse3d/services/pulse3d/src/models/models.py
@@ -34,6 +34,14 @@ class NotificationResponse(BaseModel):
     notification_type: NotificationType = NotificationType.CUSTOMERS_AND_USERS
 
 
+class NotificationMessageResponse(BaseModel):
+    id: uuid.UUID
+    created_at: datetime.datetime
+    viewed_at: datetime.datetime | None = None
+    subject: str
+    body: str
+
+
 class UploadRequest(BaseModel):
     filename: str
     md5s: str | None = Field(default=None)  # TODO when would this be None?

--- a/deployments/pulse3d/services/pulse3d/src/repository/notification_repository.py
+++ b/deployments/pulse3d/services/pulse3d/src/repository/notification_repository.py
@@ -1,4 +1,5 @@
 from models.models import (
+    NotificationMessageResponse,
     NotificationResponse,
     NotificationType,
     SaveNotificationRequest,
@@ -35,9 +36,9 @@ class NotificationRepository:
                         audience_sub_query = f"({select_user_ids_query})"
 
                 insert_notification_messages_query = f"""
-                        INSERT INTO notification_messages (notification_id, recipient_id)
-                        SELECT '{notification_id}', id from {audience_sub_query} audience;
-                    """
+                    INSERT INTO notification_messages (notification_id, recipient_id)
+                    SELECT '{notification_id}', id from {audience_sub_query} audience;
+                """
 
                 await con.execute(insert_notification_messages_query)
 
@@ -50,3 +51,24 @@ class NotificationRepository:
             notifications = await con.fetch(query)
 
         return [NotificationResponse(**dict(notification)) for notification in notifications]
+
+    async def get_notification_messages(
+        self, account_id: str, notification_message_id: str
+    ) -> list[NotificationMessageResponse]:
+        query = f"""
+            SELECT m.id, m.created_at, m.viewed_at, n.subject, n.body
+            FROM notification_messages m, notifications n
+            WHERE m.recipient_id = '{account_id}'
+            AND m.notification_id = n.id
+        """
+
+        if notification_message_id:
+            query += f" AND m.id = '{notification_message_id}'"
+
+        async with self.pool.acquire() as con:
+            notification_messages = await con.fetch(query)
+
+        return [
+            NotificationMessageResponse(**dict(notification_message))
+            for notification_message in notification_messages
+        ]

--- a/deployments/pulse3d/services/pulse3d/src/service/notification_service.py
+++ b/deployments/pulse3d/services/pulse3d/src/service/notification_service.py
@@ -20,7 +20,7 @@ class NotificationService:
         return notifications
 
     async def get_notification_messages(
-        self, account_id: str, notification_message_id: str
+        self, account_id: str, notification_message_id: str | None
     ) -> list[NotificationMessageResponse]:
         notification_messages = await self.repository.get_notification_messages(
             account_id, notification_message_id

--- a/deployments/pulse3d/services/pulse3d/src/service/notification_service.py
+++ b/deployments/pulse3d/services/pulse3d/src/service/notification_service.py
@@ -1,4 +1,9 @@
-from models.models import NotificationResponse, SaveNotificationRequest, SaveNotificationResponse
+from models.models import (
+    NotificationMessageResponse,
+    NotificationResponse,
+    SaveNotificationRequest,
+    SaveNotificationResponse,
+)
 from repository.notification_repository import NotificationRepository
 
 
@@ -13,3 +18,11 @@ class NotificationService:
     async def get_all(self) -> list[NotificationResponse]:
         notifications = await self.repository.get_all()
         return notifications
+
+    async def get_notification_messages(
+        self, account_id: str, notification_message_id: str
+    ) -> list[NotificationMessageResponse]:
+        notification_messages = await self.repository.get_notification_messages(
+            account_id, notification_message_id
+        )
+        return notification_messages


### PR DESCRIPTION
I wanted this endpoint to be able to return all notifications (for the first FE query) and single notifications (for event-source updates)

Example returning all notification_messages for a customer
<img width="477" alt="Screenshot 2024-10-04 at 2 05 32 PM" src="https://github.com/user-attachments/assets/701516f2-4b92-4ff2-bef9-e7aeb7cbe729">

Example returning one notification_message for a user
<img width="809" alt="Screenshot 2024-10-04 at 2 03 17 PM" src="https://github.com/user-attachments/assets/ff4bdeb6-464c-4d69-81e5-dc2564df43ec">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208471898377281