### PR TITLE
Create endpoint to mark notification_messages as viewed

### DIFF
--- a/deployments/pulse3d/services/pulse3d/src/main.py
+++ b/deployments/pulse3d/services/pulse3d/src/main.py
@@ -968,7 +968,7 @@ async def get_notification_messages(
 
 @app.post("/notification_messages", response_model=ViewNotificationMessageResponse)
 async def view_notification_message(
-    view_request: ViewNotificationMessageRequest, token=Depends(ProtectedAny(tag=ScopeTags.PULSE3D_WRITE))
+    view_request: ViewNotificationMessageRequest, token=Depends(ProtectedAny(scopes=list(Scopes)))
 ):
     """Mark user|customer notification messages as viewed."""
     try:

--- a/deployments/pulse3d/services/pulse3d/src/main.py
+++ b/deployments/pulse3d/services/pulse3d/src/main.py
@@ -89,6 +89,8 @@ from models.models import (
     UploadRequest,
     UploadResponse,
     UsageQuota,
+    ViewNotificationMessageRequest,
+    ViewNotificationMessageResponse,
     WaveformDataResponse,
     GetJobsRequest,
 )
@@ -961,6 +963,22 @@ async def get_notification_messages(
         return response
     except Exception:
         logger.exception("Failed to get notification messages")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@app.post("/notification_messages", response_model=ViewNotificationMessageResponse)
+async def view_notification_message(
+    view_request: ViewNotificationMessageRequest, token=Depends(ProtectedAny(tag=ScopeTags.PULSE3D_WRITE))
+):
+    """Mark user|customer notification messages as viewed."""
+    try:
+        account_id = str(uuid.UUID(token.account_id))
+        nm_id = str(view_request.id)
+        bind_context_to_logger({"account_id": account_id})
+        response = await notification_service.view_notification_message(account_id, nm_id)  # noqa: F821
+        return response
+    except Exception:
+        logger.exception("Failed to mark notification message as viewed")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 

--- a/deployments/pulse3d/services/pulse3d/src/models/models.py
+++ b/deployments/pulse3d/services/pulse3d/src/models/models.py
@@ -26,6 +26,14 @@ class SaveNotificationResponse(BaseModel):
     id: uuid.UUID
 
 
+class ViewNotificationMessageRequest(BaseModel):
+    id: uuid.UUID
+
+
+class ViewNotificationMessageResponse(BaseModel):
+    viewed_at: datetime.datetime | None = None
+
+
 class NotificationResponse(BaseModel):
     id: uuid.UUID
     created_at: datetime.datetime

--- a/deployments/pulse3d/services/pulse3d/src/service/notification_service.py
+++ b/deployments/pulse3d/services/pulse3d/src/service/notification_service.py
@@ -3,6 +3,7 @@ from models.models import (
     NotificationResponse,
     SaveNotificationRequest,
     SaveNotificationResponse,
+    ViewNotificationMessageResponse,
 )
 from repository.notification_repository import NotificationRepository
 
@@ -26,3 +27,9 @@ class NotificationService:
             account_id, notification_message_id
         )
         return notification_messages
+
+    async def view_notification_message(
+        self, account_id: str, notification_message_id: str
+    ) -> ViewNotificationMessageResponse:
+        response = await self.repository.view_notification_message(account_id, notification_message_id)
+        return response


### PR DESCRIPTION
Example running the same request twice:

First run
<img width="530" alt="Screenshot 2024-10-09 at 12 04 42 PM" src="https://github.com/user-attachments/assets/f5ffbc67-5deb-4423-9c64-09c354f2a332">

Repeat
<img width="530" alt="Screenshot 2024-10-09 at 12 06 08 PM" src="https://github.com/user-attachments/assets/2f7a4ef4-dd65-44ed-b8bc-66e4e4f1990e">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208494116369388