### PR TITLE
Fix preset deletion cancel

### DIFF
--- a/frontend/pulse3d/src/components/uploadForm/AnalysisParamForm.js
+++ b/frontend/pulse3d/src/components/uploadForm/AnalysisParamForm.js
@@ -1193,10 +1193,9 @@ export default function AnalysisParamForm({
         ]}
         buttons={["Cancel", "Delete"]}
         closeModal={async (idx) => {
-          let success = true;
-
           const presetName = userPresets?.[presetDeletionIdx]?.name;
           if (idx === 1) {
+            let success = true;
             try {
               const res = await fetch(`${process.env.NEXT_PUBLIC_PULSE3D_URL}/presets/${presetName}`, {
                 method: "DELETE",
@@ -1206,10 +1205,10 @@ export default function AnalysisParamForm({
               console.log("ERROR delete analysis param preset", e);
               success = false;
             }
-          }
-          if (success) {
-            userPresets.splice(presetDeletionIdx, 1);
-            setUserPresets([...userPresets]);
+            if (success) {
+              userPresets.splice(presetDeletionIdx, 1);
+              setUserPresets([...userPresets]);
+            }
           }
           setPresetDeletionIdx(-1);
         }}

--- a/frontend/pulse3d/src/pages/notification-messages.js
+++ b/frontend/pulse3d/src/pages/notification-messages.js
@@ -93,6 +93,20 @@ export default function NotificationMessages() {
             <UnreadMessageFormatting>{cell.getValue()}</UnreadMessageFormatting>
           ),
       },
+      {
+        accessorKey: "viewed",
+        header: "Status",
+        size: 310,
+        minSize: 200,
+        enableSorting: true,
+        enableColumnActions: false,
+        Cell: ({ row }) =>
+          row.original.viewed ? (
+            <ReadMessageFormatting>Read</ReadMessageFormatting>
+          ) : (
+            <UnreadMessageFormatting>Unread</UnreadMessageFormatting>
+          ),
+      },
     ],
     []
   );

--- a/frontend/pulse3d/src/pages/notifications-management.js
+++ b/frontend/pulse3d/src/pages/notifications-management.js
@@ -113,14 +113,13 @@ export default function NotificationsManagement() {
       {
         accessorKey: "id",
         header: "Notification ID",
-        size: 200,
+        size: 330,
         minSize: 200,
-        Cell: ({ cell }) => getShortUUIDWithTooltip(cell.getValue(), 8),
       },
       {
         accessorKey: "subject",
         header: "Subject",
-        size: 580,
+        size: 780,
         minSize: 400,
       },
       {


### PR DESCRIPTION
Also:
- Tweak widths of notifications creation table to fill full page
- Add read/unread col to notifications message table. Table did not seem to want to let the "subject" col grow larger than 1000px, so I added this col to fill the remaining width. Users can sort by this col to quickly bring all unread notifications to the top