### PR TITLE
convert query result for `current_job_count` into an int so comparison

### DIFF
--- a/core/lib/jobs/jobs/jobs.py
+++ b/core/lib/jobs/jobs/jobs.py
@@ -786,6 +786,7 @@ async def check_customer_advanced_analysis_usage(con, customer_id):
     current_job_count = await con.fetchval(
         "SELECT COUNT(*) FROM advanced_analysis_result WHERE customer_id=$1", customer_id
     )
+    current_job_count = int(current_job_count)
 
     usage_limits = json.loads(usage_limits_json)
 

--- a/core/lib/jobs/setup.py
+++ b/core/lib/jobs/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="jobs",
-    version="0.0.2",
+    version="0.0.3",
     description="CuriBio jobs queue",
     packages=find_packages(include=["jobs"]),
     install_requires=[


### PR DESCRIPTION
doesn't happend between str and int in usage check